### PR TITLE
Add tempo and points-if-bought to state vector (326 -> 386)

### DIFF
--- a/Splendor/Environment/Splendor_components/Player_components/player.py
+++ b/Splendor/Environment/Splendor_components/Player_components/player.py
@@ -308,6 +308,17 @@ class Player:
 
         return state_vector  # length 47
 
+    def tempo_and_winrate(self, cards) -> ndarray:
+        """Can-buy-now bool and points-if-bought for a fixed-size card list."""
+        n = len(cards)
+        features = np.zeros(n * 2, dtype=np.float32)
+        for i, card in enumerate(cards):
+            if card:
+                _, afford = self.can_afford_card(card)
+                features[i] = float(afford)
+                features[n + i] = (self.points + card.points) / 15
+        return features
+
     def clone(self):
         clone = Player.__new__(Player)
         clone.__dict__ = self.__dict__.copy()

--- a/Splendor/Environment/gui_game.py
+++ b/Splendor/Environment/gui_game.py
@@ -186,10 +186,16 @@ class GUIGame:
         cur_player = self.active_player
         enemy_player = self.players[(self.half_turns+1) % 2]
 
-        board_vector = self.board.to_state(cur_player.effective_gems,         # 232
-                                          enemy_player.effective_gems)
-        hero_vector = self.active_player.to_state()                          # 47
-        enemy_vector = enemy_player.to_state()                               # 47
+        board_vector = self.board.to_state(cur_player.effective_gems,          # 232
+                                           enemy_player.effective_gems)
+        cur_vector = cur_player.to_state()                                    # 47
+        enemy_vector = enemy_player.to_state()                                # 47
 
-        vector = np.concatenate((board_vector, hero_vector, enemy_vector))   # 326
+        # Tempo (can-buy-now) and points-if-bought, both perspectives (60)
+        shop_cards = [c for tier in self.board.cards for c in tier]
+        pad = [None] * 3
+        cur_cards = shop_cards + (cur_player.reserved_cards + pad)[:3]
+        enemy_cards = shop_cards + (enemy_player.reserved_cards + pad)[:3]
+
+        vector = np.concatenate((board_vector, cur_vector, enemy_vector, cur_player.tempo_and_winrate(cur_cards), enemy_player.tempo_and_winrate(enemy_cards)))  # 386
         return vector.astype(np.float32)

--- a/Splendor/Environment/rl_game.py
+++ b/Splendor/Environment/rl_game.py
@@ -151,8 +151,14 @@ class RLGame:
 
         board_vector = self.board.to_state(cur_player.effective_gems,       # 232
                                            enemy_player.effective_gems)
-        hero_vector = self.active_player.to_state()                         # 47
+        cur_vector = cur_player.to_state()                                  # 47
         enemy_vector = enemy_player.to_state()                              # 47
 
-        vector = np.concatenate((board_vector, hero_vector, enemy_vector))  # 326
+        # Tempo (can-buy-now) and points-if-bought, both perspectives (60)
+        shop_cards = [c for tier in self.board.cards for c in tier]
+        pad = [None] * 3
+        cur_cards = shop_cards + (cur_player.reserved_cards + pad)[:3]
+        enemy_cards = shop_cards + (enemy_player.reserved_cards + pad)[:3]
+
+        vector = np.concatenate((board_vector, cur_vector, enemy_vector, cur_player.tempo_and_winrate(cur_cards), enemy_player.tempo_and_winrate(enemy_cards)))  # 386
         return vector.astype(np.float32)

--- a/Splendor/RL/inference_model.py
+++ b/Splendor/RL/inference_model.py
@@ -10,7 +10,7 @@ class InferenceAgent:
         # enable_unsafe_deserialization()
 
         # Dimensions
-        self.state_dim = 326
+        self.state_dim = 386
         self.action_dim = 141
         self.batch_size = 512
 

--- a/Splendor/RL/model.py
+++ b/Splendor/RL/model.py
@@ -26,7 +26,7 @@ class RLAgent:
         self.huber = Huber()
 
         # Dimensions
-        self.state_dim = 326
+        self.state_dim = 386
         self.action_dim = 141
         self.batch_size = 512
 

--- a/Splendor/RL/random_model.py
+++ b/Splendor/RL/random_model.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 class RandomAgent:
     def __init__(self, paths):
         self.paths = paths
-        self.state_size = 326
+        self.state_size = 386
         self.action_size = 141
         self.memory = self.load_memory()
         self.step = 0


### PR DESCRIPTION
Tempo (30): bool per card indicating if each player can buy it right now (accounting for gold substitution). Covers 12 shop + 3 reserved per player perspective.

Points-if-bought (30): (player.points + card.points) / 15 for each card from both perspectives, surfacing win-proximity without the network needing to internally add scores.

https://claude.ai/code/session_01UUgtaumKLeVArQiqiy5a2W